### PR TITLE
Updated 02461 installation instructions

### DIFF
--- a/docs/courses/02461/E2023.rst
+++ b/docs/courses/02461/E2023.rst
@@ -1,20 +1,19 @@
 E2023
 =====
 
-This guideline is for students attending course 02461 in Autumn 2023.
+This guideline is for students attending course :course-base:`02461` in Autumn 2023.
 
 Please follow this guideline:
 
 1. Install Python by following :ref:`this guide <install-python>`.
 
 2. Install VS Code by following :ref:`this guide <ide-vscode>`.
-   Install the extensions Python and Jupyter.
+   Install the extensions ``Python`` and ``Jupyter``.
 
-3. Create a virtual environment called IntelligentSystems using venv, following :ref:`this guide <environments>`.
-   .. code-block::
-      
-      python -m venv IntelligentSystems
-
+3. Create a virtual environment called ``IntelligentSystems`` using ``venv``.
+   More details can be found in :ref:`this guide <environments>`.
+   If you will retain all course material in a VS Code workspace, you should follow
+   :ref:`this FAQ entry <faq-vscode-venv-workspace>`.
       
 4. Activate the virtual environment and install these packages with :ref:`pip`.
    Copy-paste the below to the ``pip install`` command line as shown in :ref:`pip-installing`

--- a/docs/courses/02461/E2023.rst
+++ b/docs/courses/02461/E2023.rst
@@ -5,14 +5,18 @@ This guideline is for students attending course 02461 in Autumn 2023.
 
 Please follow this guideline:
 
-1. Install Python by following :ref:`this guide <install-python>`
+1. Install Python by following :ref:`this guide <install-python>`.
 
-2. Install VS Code by following :ref:`this guide <ide-vscode>`
+2. Install VS Code by following :ref:`this guide <ide-vscode>`.
+   Install the extensions Python and Jupyter.
 
-3. Create a virtual environment in VS Code, follow
-   :ref:`this FAQ entry <faq-vscode-venv-workspace>`.
+3. Create a virtual environment called IntelligentSystems using venv, following :ref:`this guide <environments>`.
+   .. code-block::
+      
+      python -m venv IntelligentSystems
 
-4. Install these packages with :ref:`pip`.
+      
+4. Activate the virtual environment and install these packages with :ref:`pip`.
    Copy-paste the below to the ``pip install`` command line as shown in :ref:`pip-installing`
 
    .. code-block::

--- a/docs/courses/02461/index.rst
+++ b/docs/courses/02461/index.rst
@@ -3,7 +3,7 @@
 :course-base:`02461`
 ========================
 
-Find your study year below:
+Find your study year below, the course database site is :course-base:`here <02461>`:
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Looks great, but I have a few suggestions
- We could write that they should install the VSCode extensions Python and Jupyter
- Regarding venv, I think it might be better to link to this  https://pythonsupport.dtu.dk/python/environments.html and tell them to create a virtual environment using venv. Once they have done that, they should be able to activate it in VSCode.


