### PR TITLE
Added Dockerfile, simple "how to" in README.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+####################
+# - Stage: Builder
+####################
+FROM docker.io/python:3.11-slim-bookworm as base-python
+WORKDIR /app-src
+
+# Build Variables
+ENV PIP_DISABLE_PIP_VERSION_CHECK 1
+ENV PIP_NO_CACHE_DIR 1
+## Disable Non-Reproducible pip
+
+# Runtime Variables
+ENV PYTHONOPTIMIZE 1
+ENV PYTHONUNBUFFERED 1
+
+# Get Make
+RUN apt update \
+	&& apt install --no-install-recommends -y \
+		make libenchant-2-2
+
+# Buffering
+COPY ./ /app-src/
+RUN pip install -r requirements.txt
+RUN make all
+
+
+
+####################
+# - Stage: Production
+####################
+FROM ghcr.io/static-web-server/static-web-server:2-debian as production
+
+RUN apt update \
+	&& apt upgrade -y \
+	&& apt install --no-install-recommends -y \
+		curl
+
+RUN groupadd -g 5000 sws && \
+	useradd -m -u 5000 -g sws sws
+
+COPY --from=base-python --chown=sws:sws /app-src/build/html/ /app
+
+USER sws
+WORKDIR /app
+
+HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1
+
+ENV SERVER_PORT 3000
+ENV SERVER_ROOT /app
+ENV SERVER_LOG_REMOTE_ADDRESS false

--- a/README.md
+++ b/README.md
@@ -8,3 +8,17 @@ Our homepage is hosted [here](https://pythonsupport.dtu.dk).
 If you are a DTU student and want help with installing
 packages for a course at DTU, plese visit 
 [pythonsupport.dtu.dk](https://pythonsupport.dtu.dk).
+
+Running Locally in Podman
+-------------------------
+
+You can easily run the site locally (and deployed) using containers. You'll need:
+- `podman` (or `docker`)
+
+Run the following:
+```bash
+podman build . --tag pythonsupport-page:dev
+podman run --rm -it --cap-drop ALL --publish 3000:3000 pythonsupport-page:dev
+```
+
+To control things like cache headers, compression, healthcheck endpoint, and basic authentication, see the `static-web-server` environment variable reference: https://static-web-server.net/configuration/environment-variables/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-toml ; python_version <= "3.11"
+toml ; python_version < "3.11"
 
 # we should be buildalbe on any version (check minimal version)
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-toml ; python_version < "3.11"
+toml ; python_version <= "3.11"
 
 # we should be buildalbe on any version (check minimal version)
 sphinx


### PR DESCRIPTION
The Dockerfile works by building from requirements.txt, which really should be a lockfile.

It then uses static-web-server (a simple Rust-based webserver for serving static files) to serve files rootlessly.

This should be done securely (as documented) using podman, which the docs encourages to run with cap-drop ALL.