### PR TITLE
Charlie-19-August-changing-formulation-in-windows-guide

### DIFF
--- a/docs/install/windows/automated.rst
+++ b/docs/install/windows/automated.rst
@@ -37,7 +37,7 @@ Install everything at once
             :align: center
 
     #. 
-        Copy the following line of code into your terminal and press :kbd:`Enter`:
+        Copy the following line of code into the PowerShell window and press :kbd:`Enter`:
 
         .. code:: pwsh
 


### PR DESCRIPTION
Changed "paste in to your terminal" to "paste into the powershell window, because we never actually mention the word "terminal" in the guide, so a new student could potentially reach this step and have no clue what we mean by "paste into the terminal"