### PR TITLE
Moved The VSCode page out of learn more and onto main page to make it more accessible

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,7 @@ Office hours
    :hidden:
 
    install/python.rst
+   learn-more/vscode/index.rst
    course/index.rst
    learn-more/index.rst
    videos/index.rst

--- a/docs/learn-more/index.rst
+++ b/docs/learn-more/index.rst
@@ -40,7 +40,6 @@ helping you understand the basics of these tools.
    
    terminal
    IDLE (only for 02002/02003) <idle>
-   vscode/index
    packages-and-environments/index.rst
 
 


### PR DESCRIPTION
Moved the VSCode section out of the learn more, so that it is no longer a "hidden" subsection. Instead it is now on the main page after "install python" so that it is more noticeable for students. 