### PR TITLE
Fix the wrong title on the home page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -527,9 +527,22 @@ def rstjinja_include(app, relative_path, parent_docname, content):
     """include-read event"""
     content[0] = rstjinja(app, content[0])
 
+def add_title_to_context(app, pagename, templatename, context, doctree):
+    # If there's no document tree (e.g., for special pages like search or genindex), do nothing.
+    if doctree is None:
+        return
+    
+    # Retrieve metadata for the current page
+    metadata = app.env.metadata.get(pagename, {})
+
+    # If a 'title' is specified in the page metadata, add it to the template context
+    title = metadata.get('title')
+    if title:
+        context['title'] = title
 
 def setup(app):
 
     app.connect("source-read", rstjinja_source)
     app.connect("include-read", rstjinja_include)
+    app.connect("html-page-context", add_title_to_context)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,5 @@
 :html_theme.sidebar_secondary.remove: true
+:title: DTU Python Installation Support
 
 .. meta::
    :description: Technical University of Denmark (DTU) Python Installation Support


### PR DESCRIPTION
This pull implements a small Sphinx add-on that injects a custom header title into the page. A custom title is set via the :title: metadata field.

This pull fixes the wrong title of the home page: "Reach us" (Before) -> "DTU Python Installation Support" (After), that was caused by the implementation of the hero section.