### PR TITLE
Added custom css for tables

### DIFF
--- a/docs/_static/css/custom_styles.css
+++ b/docs/_static/css/custom_styles.css
@@ -411,6 +411,14 @@ hovers that are also interfering so it doesn't have effect on all  */
     --bs-btn-disabled-border-color: var(--dtu-red);
   }
 
+  .table thead tr {
+    border-bottom: 2px solid var(--dtu-red-corporate) !important;
+  }
+
+  .table tbody tr:hover {
+    background-color: var(--dtu-red) !important;
+  }
+
   /* Changes the aesthetics of the search button in the toggle primary side bar */
   .btn.btn-sm.navbar-btn.search-button.search-button__button:hover {
     color: var(--bg-primary);


### PR DESCRIPTION
This pull adds custom css to tables that makes them align to the DTU colors.
This includes:
1. Changes the table head bottom border color from blue to DTU corporate red.
2. Changes the color when hovering over a table row from purple to DTU red.

This is done by overriding the existing styles found in bootstraps _mixins.scss, with the identifiers:
.table thead tr (For table head)
.table tbody tr:hover (For hovering effects)



Before
<img width="1026" alt="image" src="https://github.com/user-attachments/assets/830c1f3a-0efd-4e3e-b196-71171fafc1a1" />


After
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/59c47f7f-6124-4b88-8a08-0322241c8f55" />
