### PR TITLE
Python capitalization in hero

### DIFF
--- a/docs/html/hero.html
+++ b/docs/html/hero.html
@@ -9,7 +9,7 @@
             <h1 class="display-4 fw-bold lh-1 mb-3">DTU Python Installation Support</h1>
             <p class="fs-5 text">Our goal is to ensure that students can get a Python environment up and running according to the needs of DTU courses.</p>
             <div class="d-grid gap-2 d-md-flex justify-content-md-start">
-                <button type="button" class="btn btn-primary btn-lg px-4 me-md-2" onclick="PyS_redirectUser('package-managed.html');">Download python</button>
+                <button type="button" class="btn btn-primary btn-lg px-4 me-md-2" onclick="PyS_redirectUser('package-managed.html');">Download Python</button>
                 <a href="learn-more/index.html" class="btn btn-link btn-lg px-4">See tutorials</a>
             </div>
         </div>


### PR DESCRIPTION
This pull add proper capitalization of *Python* in the hero button: **Download Python**.