### PR TITLE
Removed syntax error from make gifs command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ livehtml:
 
 
 gifs:
-	(cd docs/os/gifs ; bash create.sh)t
+	(cd docs/os/gifs ; bash create.sh)


### PR DESCRIPTION
This pull fixes a typo (an erroneous "t") from the makefile which caused a syntax error when trying to render gifs.