### PR TITLE
added direct installer links for visual studio code

### DIFF
--- a/docs/install/macos/manual.rst
+++ b/docs/install/macos/manual.rst
@@ -94,14 +94,7 @@ Step 3: Install Visual Studio Code
    
    #.
    
-      Go to `this website  <https://code.visualstudio.com/Download#>`__.
-      
-   #. 
-      Click the **Mac** button and follow the instructions.
-
-      .. image:: /images/install/macos-fully-manual-vsc-webpage.png
-         :width: 500
-         :align: center
+      Click `here  <https://code.visualstudio.com/Download#>`__ to download Visual Studio Code.
 
    #. 
       Make sure that Visual Studio Code is under the |applications| folder in Finder.

--- a/docs/install/windows/manual.rst
+++ b/docs/install/windows/manual.rst
@@ -96,14 +96,10 @@ Step 3: Install Visual Studio Code
 .. card:: 
 
    #.
-      Go to `this website  <https://code.visualstudio.com/Download>`__.
+      Click `here  <https://code.visualstudio.com/sha/download?build=stable&os=win32-x64-user>`__ to download the installer.
    
    #.
-      Click the **Windows** button and follow the instructions.
-
-      .. image:: /images/install/windows-fully-manual-vsc-webpage.png
-         :width: 500
-         :align: center
+      Open the installer and follow the instructions.
       
 
 .. _install-python-windows-vscode-exts:


### PR DESCRIPTION
Adding direct links to installers for visual studio code to the manual guides, to make them shorter