### PR TITLE
Gitignore for rendered gifs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ Thumbs.db
 ehthumbs.db
 
 .fake
+
+# gif files
+docs/os/gifs/**/*.gif
+docs/os/gifs/tmp/*
+docs/os/gifs/commands.run
+docs/os/gifs/hashes.yml

--- a/docs/os/gifs/.gitignore
+++ b/docs/os/gifs/.gitignore
@@ -1,4 +1,0 @@
-*.gif
-tmp/*
-commands.run
-hashes.yml

--- a/docs/os/gifs/.gitignore
+++ b/docs/os/gifs/.gitignore
@@ -1,0 +1,4 @@
+*.gif
+tmp/*
+commands.run
+hashes.yml


### PR DESCRIPTION
This pull adds a gitignore for the files associated with rendering gifs.