### PR TITLE
Link button color change (again)

### DIFF
--- a/docs/_static/css/custom_styles.css
+++ b/docs/_static/css/custom_styles.css
@@ -399,6 +399,11 @@ hovers that are also interfering so it doesn't have effect on all  */
     display: none !important;
   }
 
+  /* This changes the button links from the default blue to dtu-red */
+  .btn-link {
+    color: var(--dtu-red) !important;
+  }
+
   .btn-primary {
     --bs-btn-color: var(--dtu-white);
     --bs-btn-bg: var(--dtu-red);


### PR DESCRIPTION
This pull fixes the style issue with the "see tutorials" button in the hero. The button color is changed to match to adhere to the red color theme. Merge [this pull](https://github.com/dtudk/pythonsupport-page/pull/150) before adding this one.