### PR TITLE
Adds custom javascript to auto-open referenced dropdowns

### DIFF
--- a/docs/_static/js/auto-open-dropdown-link.js
+++ b/docs/_static/js/auto-open-dropdown-link.js
@@ -1,0 +1,12 @@
+document.addEventListener("DOMContentLoaded", function () {
+  // Gets the #{id} from the url
+  const hash = window.location.hash.substring(1);
+  if (hash) {
+    // Gets the DOM element by id of the referenced hash
+    const el = document.getElementById(hash);
+    // If the element is found set the open class
+    if (el && el.tagName.toLowerCase() === "details") {
+      el.setAttribute("open", "true");
+    }
+  }
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,6 +301,7 @@ html_js_files = [
     "js/external_tab.js",
     "js/custom.js",
     "js/piwik.js",
+    "js/auto-open-dropdown-link.js",
 ]
 
 html_css_files = [


### PR DESCRIPTION
This pull adds custom javascript to auto-open referenced dropdowns. Without this the browser would scroll to the dropdown without the dropdown opening. 
That is, the dropdown

```{rst}
.. dropdown:: My dropdown
    :name: test <- Should be unique
```

can be linked to with siteurl/page.html#test, with auto-opening.