### PR TITLE
Improve build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The steps can be outlined like this:
        python3 -m venv ps-page-env
        source ps-page-env/bin/activate
 
+   `ps-page-env/bin/` contains other scripts like `activate.fish` if you use a
+   different shell. The default will work for Bash and Zsh.
+
 2. Install the requirements:
 
        ps-page-env/bin/pip install -r requirements.txt sphinx-autobuild
@@ -48,7 +51,7 @@ The steps can be outlined like this:
 
    Now the documentation is build and can be found in `build/html`.
 
-5. Open the documentation:
+5. Open the documentation (replace `firefox` with the browser of your choice):
 
        firefox build/html/index.html
 


### PR DESCRIPTION
Very small improvements

Note: using the venv pip is necessary in cases where python packages are externally managed. This is the case with many Linux distributions and sometimes with Conda.