### PR TITLE
Redo Learn landing page

### DIFF
--- a/docs/_static/css/custom_styles.css
+++ b/docs/_static/css/custom_styles.css
@@ -1099,3 +1099,218 @@ since it is also on the header.
 html[data-theme="dark"] .env-search::placeholder {
   color: darkgray;
 }
+
+/* vvvvv PYTHON SUPPORT LANDING CARD LIST vvvvv */
+
+/* The RST uses PyS_* class names; Docutils writes them as lowercase HTML classes. */
+
+/* Keep pages that use this landing component at a readable, card-friendly width. */
+.bd-article-container:has(.pys-learnlandingpage) {
+  max-width: 1120px !important;
+}
+
+/* Hide previous/next navigation on pages that act as standalone landing pages. */
+.bd-main:has(.pys-learnlandingpage) .prev-next-footer {
+  display: none;
+}
+
+/* Landing section heading inside the page wrapper. */
+.pys-learnlandingpage .rubric {
+  font-size: 2.15rem;
+  /* Keeps the rubric visually close to the original second-level heading. */
+  font-weight: 800;
+  line-height: 1.15;
+  margin: 3rem 0 1.25rem;
+  /* Gives the intro text room before the card list begins. */
+}
+
+/* Landing card list container. These variables control the reusable layout. */
+.pys-learnlandingcards {
+  margin-top: 0.75rem;
+  /* Space between the intro/heading and the first card. */
+  --PyS-learn-badge-center: 5%;
+  /* Horizontal center point for the numbered badge. */
+  --PyS-learn-badge-size: 2.6rem;
+  /* Width and height of the numbered badge. */
+  --PyS-learn-card-height: 7.2rem;
+  /* Fixed desktop height so all cards line up evenly. */
+  --PyS-learn-icon-inset: 3%;
+  /* Distance from the right card edge to the action icon. */
+  --PyS-learn-text-start: 11%;
+  /* Left padding where the card title and description begin. */
+}
+
+/* Reset the CSS counter once for each Sphinx Design grid row. */
+.pys-learnlandingcards .sd-row {
+  counter-reset: PyS_learnLandingCard;
+}
+
+/* Base card layout used by each landing option. */
+.pys-learnlandingcards .sd-card.pys-learnlandingcard {
+  counter-increment: PyS_learnLandingCard;
+  /* Increases the visible card number. */
+  display: grid;
+  /* Lets the card body and stretched link share the same card area. */
+  grid-template-columns: minmax(0, 1fr);
+  /* Keeps the card text column responsive. */
+  align-items: center;
+  /* Vertically centers the card body in the fixed-height card. */
+  height: var(--PyS-learn-card-height);
+  /* Gives every desktop card the same height. */
+  padding: 1rem 7% 1rem var(--PyS-learn-text-start);
+  /* Leaves room for the number badge on the left and icon on the right. */
+  border-radius: 8px;
+  /* Matches the site's card corner style. */
+  position: relative;
+  /* Anchors the number badge and action icon pseudo-elements. */
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  /* Smooth hover feedback without moving surrounding content. */
+}
+
+/* Make the Sphinx Design stretched link cover the full custom grid card. */
+.pys-learnlandingcards .sd-card.pys-learnlandingcard>.sd-stretched-link {
+  grid-column: 1 / -1;
+  grid-row: 1;
+}
+
+/* Number badge shown on the left side of each card. */
+.pys-learnlandingcards .sd-card.pys-learnlandingcard::before {
+  content: counter(PyS_learnLandingCard);
+  /* Prints the current card number. */
+  display: inline-grid;
+  /* Enables simple centering of the number. */
+  place-items: center;
+  /* Centers the number inside the badge. */
+  position: absolute;
+  /* Positions the badge independently of the card body text. */
+  top: 50%;
+  left: var(--PyS-learn-badge-center);
+  transform: translate(-50%, -50%);
+  /* Centers the badge exactly around its target point. */
+  width: var(--PyS-learn-badge-size);
+  height: var(--PyS-learn-badge-size);
+  border: 2px solid var(--dtu-red);
+  border-radius: 8px;
+  color: var(--dtu-red);
+  font-size: 1.05rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+/* Action icon shown on the right side of each card. */
+.pys-learnlandingcards .sd-card.pys-learnlandingcard::after {
+  display: inline-grid;
+  /* Enables simple centering of the icon glyph. */
+  place-items: center;
+  /* Centers the icon inside its pseudo-element box. */
+  position: absolute;
+  /* Positions the icon independently of the card body text. */
+  top: 50%;
+  right: var(--PyS-learn-icon-inset);
+  transform: translateY(-50%);
+  /* Vertically centers the icon. */
+  color: var(--dtu-blue);
+  font-family: "Font Awesome 6 Free";
+  /* Uses the icon font already loaded by the site. */
+  font-size: 1.35rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+/* Card 1 icon: arrow to support/contact information. */
+.pys-learnlandingcards .sd-col:nth-child(1) .sd-card.pys-learnlandingcard::after {
+  content: "\f061";
+}
+
+/* Card 2 icon: download/install guide. */
+.pys-learnlandingcards .sd-col:nth-child(2) .sd-card.pys-learnlandingcard::after {
+  content: "\f019";
+}
+
+/* Card 3 icon: code editor/tutorials. */
+.pys-learnlandingcards .sd-col:nth-child(3) .sd-card.pys-learnlandingcard::after {
+  content: "\f121";
+}
+
+/* Card 4 icon: environments/packages. */
+.pys-learnlandingcards .sd-col:nth-child(4) .sd-card.pys-learnlandingcard::after {
+  content: "\f5fd";
+}
+
+/* Card 5 icon: terminal. */
+.pys-learnlandingcards .sd-col:nth-child(5) .sd-card.pys-learnlandingcard::after {
+  content: "\f120";
+}
+
+/* Hover state for mouse users. */
+.pys-learnlandingcards .sd-card.pys-learnlandingcard:hover {
+  border-color: var(--dtu-red) !important;
+  /* Overrides the Sphinx Design default hover border. */
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.08);
+  /* Adds a subtle lift. */
+  transform: translateY(-1px);
+  /* Moves the card slightly without changing layout. */
+}
+
+/* Card body grid keeps titles and descriptions aligned between cards. */
+.pys-learnlandingcards .sd-card-body {
+  display: grid;
+  grid-template-rows: 1.45rem 2.6rem;
+  /* Reserves consistent vertical slots for title and description. */
+  align-content: start;
+  align-self: center;
+  gap: 0.45rem;
+  height: 4.5rem;
+  min-width: 0;
+  padding: 0;
+}
+
+/* Card title typography. */
+.pys-learnlandingcards .sd-card-title {
+  font-size: 1.06rem;
+  line-height: 1.25;
+  margin-bottom: 0;
+}
+
+/* Card description typography. */
+.pys-learnlandingcards .sd-card-text {
+  font-size: 0.95rem;
+  line-height: 1.35;
+  margin: 0;
+}
+
+/* Mobile layout: stack the number badge into the card grid and hide action icons. */
+@media (max-width: 600px) {
+
+  /* Mobile cards grow with their content instead of using the desktop fixed height. */
+  .pys-learnlandingcards .sd-card.pys-learnlandingcard {
+    grid-template-columns: 3.25rem minmax(0, 1fr);
+    gap: 0.85rem;
+    height: auto;
+    min-height: var(--PyS-learn-card-height);
+    padding: 1rem;
+  }
+
+  /* Mobile number badge becomes part of the card grid. */
+  .pys-learnlandingcards .sd-card.pys-learnlandingcard::before {
+    position: static;
+    transform: none;
+    width: 2.35rem;
+    height: 2.35rem;
+    font-size: 1rem;
+  }
+
+  /* Mobile card text uses natural height to avoid overflow. */
+  .pys-learnlandingcards .sd-card-body {
+    height: auto;
+    grid-template-rows: auto auto;
+    align-content: center;
+  }
+
+  /* Mobile layout removes the decorative action icon to save horizontal space. */
+  .pys-learnlandingcards .sd-card.pys-learnlandingcard::after {
+    display: none;
+  }
+}
+
+/* ^^^^^ PYTHON SUPPORT LANDING CARD LIST ^^^^^ */

--- a/docs/landing-page/learn.rst
+++ b/docs/landing-page/learn.rst
@@ -1,47 +1,209 @@
 :orphan:
+:html_theme.sidebar_secondary.remove: true
+:title: DTU Python Installation Support
 
 .. meta::
-   :description: Technical University of Denmark (DTU) Learn landing page
-   :keywords: Learn, teaching, DTU
+   :description: DTU Python Installation Support landing page for Learn
+   :keywords: DTU, Learn, Python, installation, support, VS Code, conda, terminal
 
+Welcome to DTU Python Installation Support
+==========================================
 
-Welcome to Python Installation Support. You have reached this page
-from DTU Learn.
-In the following there are several options that could relate to your
-requirements.
+We help DTU students get a working Python setup. You can use our
+installation guides to install Python yourself, visit us or reach us on
+Discord if your current installation needs fixing, and use our tutorials
+when you want help with VS Code, conda environments, the terminal, and
+other tools used in Python courses.
 
+Here we can help you with:
+--------------------------
 
-.. contents::
-   :backlinks: none
-   :local:
+.. grid:: 1 1 1 1
+   :gutter: 1
+   :class-container: learn-landing-list
 
+   .. grid-item-card:: Fixing your current Python installation
+      :link: ../index.html#reach-us
+      :link-type: url
+      :class-card: learn-landing-card
 
-Course specific environments
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      Reach DTU Python Support if your setup is broken, confusing, or course software is not working.
 
-Python Installation Support have predefined conda Environments enabling
-to have multiple course specific Python installations co-existing.
-Please visit :ref:`this page <environments-list>` to install your course
-specific environment.
+   .. grid-item-card:: Installing Python on your computer
+      :link: ../install/python.html
+      :link-type: url
+      :class-card: learn-landing-card
 
-.. warning::
+      Go directly to the recommended installation guide for your operating system.
 
-   We only have course environments where the teacher has provided a
-   requirements list. Therefore we cannot guarentee that all courses
-   are represented.
+   .. grid-item-card:: Video tutorials and help with VS Code
+      :link: ../learn-more/vscode/index.html#learn-more-vscode
+      :link-type: url
+      :class-card: learn-landing-card
 
+      Learn how to write Python scripts, use notebooks, and select the right Python environment.
 
+   .. grid-item-card:: Video tutorials and help with conda environments
+      :link: ../learn-more/packages-and-environments/index.html#packages-and-environments
+      :link-type: url
+      :class-card: learn-landing-card
 
-Guides and videos
-^^^^^^^^^^^^^^^^^
+      Understand packages, environments, and how to keep course setups separate.
 
-At :ref:`this page <learn-more>` there is a lot of information on
+   .. grid-item-card:: Introductory video tutorials to the terminal
+      :link: ../learn-more/terminal.html#learn-more-terminal
+      :link-type: url
+      :class-card: learn-landing-card
 
-* using the :ref:`terminal <learn-more.terminal>`
+      Get comfortable with the command line commands used in Python courses and installation guides.
 
-* using :ref:`Visual Studio Code <learn-more.vscode>`
+.. raw:: html
 
-* managing and using :ref:`conda environments <packages-and-environments>`
+   <style>
+     .prev-next-footer {
+       display: none;
+     }
 
-* and much more...
+     .bd-article-container {
+       max-width: 1120px;
+     }
 
+     .learn-landing-list {
+       margin-top: 0.75rem;
+       --learn-badge-center: 5%;
+       --learn-badge-size: 2.6rem;
+       --learn-card-height: 7.2rem;
+       --learn-icon-inset: 3%;
+       --learn-text-start: 11%;
+     }
+
+     .learn-landing-list .sd-card.learn-landing-card {
+       counter-increment: learn-landing-card;
+       display: grid;
+       grid-template-columns: minmax(0, 1fr);
+       align-items: center;
+       height: var(--learn-card-height);
+       padding: 1rem 7% 1rem var(--learn-text-start);
+       border-radius: 8px;
+       position: relative;
+       transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+     }
+
+     .learn-landing-list .sd-card.learn-landing-card > .sd-stretched-link {
+       grid-column: 1 / -1;
+       grid-row: 1;
+     }
+
+     .learn-landing-list .sd-row {
+       counter-reset: learn-landing-card;
+     }
+
+     .learn-landing-list .sd-card.learn-landing-card::before {
+       content: counter(learn-landing-card);
+       display: inline-grid;
+       place-items: center;
+       position: absolute;
+       top: 50%;
+       left: var(--learn-badge-center);
+       transform: translate(-50%, -50%);
+       width: var(--learn-badge-size);
+       height: var(--learn-badge-size);
+       border: 2px solid var(--dtu-red);
+       border-radius: 8px;
+       color: var(--dtu-red);
+       font-size: 1.05rem;
+       font-weight: 800;
+       line-height: 1;
+     }
+
+     .learn-landing-list .sd-card.learn-landing-card::after {
+       display: inline-grid;
+       place-items: center;
+       position: absolute;
+       top: 50%;
+       right: var(--learn-icon-inset);
+       transform: translateY(-50%);
+       color: var(--dtu-blue);
+       font-family: "Font Awesome 6 Free";
+       font-size: 1.35rem;
+       font-weight: 900;
+       line-height: 1;
+     }
+
+     .learn-landing-list .sd-col:nth-child(1) .sd-card.learn-landing-card::after {
+       content: "\f061";
+     }
+
+     .learn-landing-list .sd-col:nth-child(2) .sd-card.learn-landing-card::after {
+       content: "\f019";
+     }
+
+     .learn-landing-list .sd-col:nth-child(3) .sd-card.learn-landing-card::after {
+       content: "\f121";
+     }
+
+     .learn-landing-list .sd-col:nth-child(4) .sd-card.learn-landing-card::after {
+       content: "\f5fd";
+     }
+
+     .learn-landing-list .sd-col:nth-child(5) .sd-card.learn-landing-card::after {
+       content: "\f120";
+     }
+
+     .learn-landing-list .sd-card.learn-landing-card:hover {
+       border-color: var(--dtu-red) !important;
+       box-shadow: 0 10px 26px rgba(0, 0, 0, 0.08);
+       transform: translateY(-1px);
+     }
+
+     .learn-landing-list .sd-card-body {
+       display: grid;
+       grid-template-rows: 1.45rem 2.6rem;
+       align-content: start;
+       align-self: center;
+       gap: 0.45rem;
+       height: 4.5rem;
+       min-width: 0;
+       padding: 0;
+     }
+
+     .learn-landing-list .sd-card-title {
+       font-size: 1.06rem;
+       line-height: 1.25;
+       margin-bottom: 0;
+     }
+
+     .learn-landing-list .sd-card-text {
+       font-size: 0.95rem;
+       line-height: 1.35;
+       margin: 0;
+     }
+
+     @media (max-width: 600px) {
+       .learn-landing-list .sd-card.learn-landing-card {
+         grid-template-columns: 3.25rem minmax(0, 1fr);
+         gap: 0.85rem;
+         height: auto;
+         min-height: var(--learn-card-height);
+         padding: 1rem;
+       }
+
+       .learn-landing-list .sd-card.learn-landing-card::before {
+         position: static;
+         transform: none;
+         width: 2.35rem;
+         height: 2.35rem;
+         font-size: 1rem;
+       }
+
+       .learn-landing-list .sd-card-body {
+         height: auto;
+         grid-template-rows: auto auto;
+         align-content: center;
+       }
+
+       .learn-landing-list .sd-card.learn-landing-card::after {
+         display: none;
+       }
+     }
+   </style>

--- a/docs/landing-page/learn.rst
+++ b/docs/landing-page/learn.rst
@@ -9,201 +9,51 @@
 Welcome to DTU Python Installation Support
 ==========================================
 
-We help DTU students get a working Python setup. You can use our
-installation guides to install Python yourself, visit us or reach us on
-Discord if your current installation needs fixing, and use our tutorials
-when you want help with VS Code, conda environments, the terminal, and
-other tools used in Python courses.
+.. container:: PyS_learnLandingPage
 
-Here we can help you with:
---------------------------
+   We help DTU students get a working Python setup. You can use our
+   installation guides to install Python yourself, visit us or reach us on
+   Discord if your current installation needs fixing, and use our tutorials
+   when you want help with VS Code, conda environments, the terminal, and
+   other tools used in Python courses.
 
-.. grid:: 1 1 1 1
-   :gutter: 1
-   :class-container: learn-landing-list
+   .. rubric:: Here we can help you with:
 
-   .. grid-item-card:: Fixing your current Python installation
-      :link: ../index.html#reach-us
-      :link-type: url
-      :class-card: learn-landing-card
+   .. grid:: 1 1 1 1
+      :gutter: 1
+      :class-container: PyS_learnLandingCards
 
-      Reach DTU Python Support if your setup is broken, confusing, or course software is not working.
+      .. grid-item-card:: Fixing your current Python installation
+         :link: ../index.html#reach-us
+         :link-type: url
+         :class-card: PyS_learnLandingCard
 
-   .. grid-item-card:: Installing Python on your computer
-      :link: ../install/python.html
-      :link-type: url
-      :class-card: learn-landing-card
+         Reach DTU Python Support if your setup is broken, confusing, or course software is not working.
 
-      Go directly to the recommended installation guide for your operating system.
+      .. grid-item-card:: Installing Python on your computer
+         :link: ../install/python.html
+         :link-type: url
+         :class-card: PyS_learnLandingCard
 
-   .. grid-item-card:: Video tutorials and help with VS Code
-      :link: ../learn-more/vscode/index.html#learn-more-vscode
-      :link-type: url
-      :class-card: learn-landing-card
+         Go directly to the recommended installation guide for your operating system.
 
-      Learn how to write Python scripts, use notebooks, and select the right Python environment.
+      .. grid-item-card:: Video tutorials and help with VS Code
+         :link: ../learn-more/vscode/index.html#learn-more-vscode
+         :link-type: url
+         :class-card: PyS_learnLandingCard
 
-   .. grid-item-card:: Video tutorials and help with conda environments
-      :link: ../learn-more/packages-and-environments/index.html#packages-and-environments
-      :link-type: url
-      :class-card: learn-landing-card
+         Learn how to write Python scripts, use notebooks, and select the right Python environment.
 
-      Understand packages, environments, and how to keep course setups separate.
+      .. grid-item-card:: Video tutorials and help with conda environments
+         :link: ../learn-more/packages-and-environments/index.html#packages-and-environments
+         :link-type: url
+         :class-card: PyS_learnLandingCard
 
-   .. grid-item-card:: Introductory video tutorials to the terminal
-      :link: ../learn-more/terminal.html#learn-more-terminal
-      :link-type: url
-      :class-card: learn-landing-card
+         Understand packages, environments, and how to keep course setups separate.
 
-      Get comfortable with the command line commands used in Python courses and installation guides.
+      .. grid-item-card:: Introductory video tutorials to the terminal
+         :link: ../learn-more/terminal.html#learn-more-terminal
+         :link-type: url
+         :class-card: PyS_learnLandingCard
 
-.. raw:: html
-
-   <style>
-     .prev-next-footer {
-       display: none;
-     }
-
-     .bd-article-container {
-       max-width: 1120px;
-     }
-
-     .learn-landing-list {
-       margin-top: 0.75rem;
-       --learn-badge-center: 5%;
-       --learn-badge-size: 2.6rem;
-       --learn-card-height: 7.2rem;
-       --learn-icon-inset: 3%;
-       --learn-text-start: 11%;
-     }
-
-     .learn-landing-list .sd-card.learn-landing-card {
-       counter-increment: learn-landing-card;
-       display: grid;
-       grid-template-columns: minmax(0, 1fr);
-       align-items: center;
-       height: var(--learn-card-height);
-       padding: 1rem 7% 1rem var(--learn-text-start);
-       border-radius: 8px;
-       position: relative;
-       transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
-     }
-
-     .learn-landing-list .sd-card.learn-landing-card > .sd-stretched-link {
-       grid-column: 1 / -1;
-       grid-row: 1;
-     }
-
-     .learn-landing-list .sd-row {
-       counter-reset: learn-landing-card;
-     }
-
-     .learn-landing-list .sd-card.learn-landing-card::before {
-       content: counter(learn-landing-card);
-       display: inline-grid;
-       place-items: center;
-       position: absolute;
-       top: 50%;
-       left: var(--learn-badge-center);
-       transform: translate(-50%, -50%);
-       width: var(--learn-badge-size);
-       height: var(--learn-badge-size);
-       border: 2px solid var(--dtu-red);
-       border-radius: 8px;
-       color: var(--dtu-red);
-       font-size: 1.05rem;
-       font-weight: 800;
-       line-height: 1;
-     }
-
-     .learn-landing-list .sd-card.learn-landing-card::after {
-       display: inline-grid;
-       place-items: center;
-       position: absolute;
-       top: 50%;
-       right: var(--learn-icon-inset);
-       transform: translateY(-50%);
-       color: var(--dtu-blue);
-       font-family: "Font Awesome 6 Free";
-       font-size: 1.35rem;
-       font-weight: 900;
-       line-height: 1;
-     }
-
-     .learn-landing-list .sd-col:nth-child(1) .sd-card.learn-landing-card::after {
-       content: "\f061";
-     }
-
-     .learn-landing-list .sd-col:nth-child(2) .sd-card.learn-landing-card::after {
-       content: "\f019";
-     }
-
-     .learn-landing-list .sd-col:nth-child(3) .sd-card.learn-landing-card::after {
-       content: "\f121";
-     }
-
-     .learn-landing-list .sd-col:nth-child(4) .sd-card.learn-landing-card::after {
-       content: "\f5fd";
-     }
-
-     .learn-landing-list .sd-col:nth-child(5) .sd-card.learn-landing-card::after {
-       content: "\f120";
-     }
-
-     .learn-landing-list .sd-card.learn-landing-card:hover {
-       border-color: var(--dtu-red) !important;
-       box-shadow: 0 10px 26px rgba(0, 0, 0, 0.08);
-       transform: translateY(-1px);
-     }
-
-     .learn-landing-list .sd-card-body {
-       display: grid;
-       grid-template-rows: 1.45rem 2.6rem;
-       align-content: start;
-       align-self: center;
-       gap: 0.45rem;
-       height: 4.5rem;
-       min-width: 0;
-       padding: 0;
-     }
-
-     .learn-landing-list .sd-card-title {
-       font-size: 1.06rem;
-       line-height: 1.25;
-       margin-bottom: 0;
-     }
-
-     .learn-landing-list .sd-card-text {
-       font-size: 0.95rem;
-       line-height: 1.35;
-       margin: 0;
-     }
-
-     @media (max-width: 600px) {
-       .learn-landing-list .sd-card.learn-landing-card {
-         grid-template-columns: 3.25rem minmax(0, 1fr);
-         gap: 0.85rem;
-         height: auto;
-         min-height: var(--learn-card-height);
-         padding: 1rem;
-       }
-
-       .learn-landing-list .sd-card.learn-landing-card::before {
-         position: static;
-         transform: none;
-         width: 2.35rem;
-         height: 2.35rem;
-         font-size: 1rem;
-       }
-
-       .learn-landing-list .sd-card-body {
-         height: auto;
-         grid-template-rows: auto auto;
-         align-content: center;
-       }
-
-       .learn-landing-list .sd-card.learn-landing-card::after {
-         display: none;
-       }
-     }
-   </style>
+         Get comfortable with the command line commands used in Python courses and installation guides.


### PR DESCRIPTION
This updates the Learn landing page to make it easier for students to read and use.

The original page has been replaced with a more concise landing page that explains what DTU Python Installation Support can help with: installing Python, fixing an existing setup, and finding help resources for VS Code, conda environments, and the terminal.

The page now uses a simple card-based layout so students can quickly scan the options and click the resource they need. 